### PR TITLE
hora field data type changed to 'time' to avoid errors

### DIFF
--- a/database/migrations/2022_08_03_120641_create_partidos_table.php
+++ b/database/migrations/2022_08_03_120641_create_partidos_table.php
@@ -17,7 +17,7 @@ return new class extends Migration
             $table->id();
 
             $table->date('fecha');
-            $table->dateTime('hora');
+            $table->time('hora');
             $table->string('ubicacion',30);
             $table->string('resultado',30)->nullable();
 


### PR DESCRIPTION
'hola' field data type changed from 'datetime' to 'time' to avoid a invalid datetime format error